### PR TITLE
add utf8 flag to open non-CP1252 txt file in Windows

### DIFF
--- a/autofill.py
+++ b/autofill.py
@@ -15,7 +15,7 @@ load_dotenv()
 
 
 cities = ["Dallas", "Austin", "Houston", "Hazel", "Fort Worth"]
-corpus = open("./corpus.txt").read()
+corpus = open("./corpus.txt",encoding='utf8').read()
 model = markovify.Text(corpus)
 input_text = ""
 for (i) in range(random.randint(1, 10)):


### PR DESCRIPTION
After 
`pip install -r requirements.txt`
and executing script on Windows 10 with Python 3.10.6 I got an error when it attempts opening corpus.txt:
```
Traceback (most recent call last):
  File "S:\src\GitHub\defend_kids\autofill.py", line 18, in <module>
    corpus = open("./corpus.txt").read()
  File "C:\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 6941: character maps to <undefined>
```

This is easily resolved by setting the encoding to utf8 explicity in the open call.

With this change, the script runs as expected on my Windows machine, and submits the form in Chrome browser.